### PR TITLE
tcti: Update mssim TCTI usage to use new key/value pair conf string.

### DIFF
--- a/man/common/tcti.md
+++ b/man/common/tcti.md
@@ -63,8 +63,8 @@ available:
   * For the mssim TCTI, the domain name or IP address and port number used by
     the simulator can be specified. The default are 127.0.0.1 and 2321.
 
-    Example: **-T mssim:tcp://127.0.0.1:2321** or
-    **export _TPM2TOOLS\_TCTI_="mssim:tcp://127.0.0.1:2321"**
+    Example: **-T mssim:host=localhost,port=2321** or
+    **export _TPM2TOOLS\_TCTI_="mssim:host=localhost,port=2321"**
 
   * **abrmd**:
     For the abrmd TCTI, the configuration string format is a series of simple

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -198,7 +198,7 @@ function start_sim() {
         kill -0 "$tpm2_sim_pid"
         if [ $? -eq 0 ]; then
             local name="com.intel.tss2.Tabrmd${tpm2_sim_port}"
-                        tpm2_tabrmd_opts="--session --dbus-name=$name --tcti=mssim:tcp://127.0.0.1:$tpm2_sim_port"
+                        tpm2_tabrmd_opts="--session --dbus-name=$name --tcti=mssim:port=$tpm2_sim_port"
             echo "tpm2_tabrmd_opts: $tpm2_tabrmd_opts"
 
             tpm2_tcti_opts="abrmd:bus_type=session,bus_name=$name"
@@ -267,11 +267,11 @@ function start_up() {
         echo "export TPM2TOOLS_TCTI=\"$tpm2_tcti_opts\""
         export TPM2TOOLS_TCTI="$tpm2_tcti_opts"
     else
-        export TPM2TOOLS_TCTI="socket:tcp://127.0.0.1:$tpm2_sim_port"
+        export TPM2TOOLS_TCTI="socket:port=$tpm2_sim_port"
         echo "Not starting tpm2-abrmd"
         echo "Setting TCTI to use mssim"
-        echo "export TPM2TOOLS_TCTI=\"socket:tcp://127.0.0.1:$tpm2_sim_port\""
-        export TPM2TOOLS_TCTI="socket:tcp://127.0.0.1:$tpm2_sim_port"
+        echo "export TPM2TOOLS_TCTI=\"socket:port=$tpm2_sim_port\""
+        export TPM2TOOLS_TCTI="socket:port=$tpm2_sim_port"
     fi
 
     echo "Running tpm2_clear"


### PR DESCRIPTION
The TCTI library isn't using URIs for the config string any longer.
Instead we're using a string of key/value pairs with 'host' and
'port' as the keys.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>